### PR TITLE
clean compile warning

### DIFF
--- a/src/cfsock.rs
+++ b/src/cfsock.rs
@@ -1,11 +1,11 @@
 use libc::*;
 use net2::{TcpBuilder, UdpBuilder};
 use std::net::{SocketAddr, SocketAddr::*};
-use std::io::{Error, ErrorKind};
 use std::os::unix::io::AsRawFd;
 
 #[cfg(target_os = "linux")]
 fn set_freebind(fd: c_int) -> Result<(), std::io::Error> {
+    use std::io::{Error, ErrorKind};
     const IP_FREEBIND: libc::c_int = 0xf;
     match unsafe {
         setsockopt(

--- a/src/ntp/client.rs
+++ b/src/ntp/client.rs
@@ -44,7 +44,7 @@ impl std::error::Error for NtpClientError {
             _ => "Connection to server failed because address could not be resolved",
         }
     }
-    fn cause(&self) -> Option<&std::error::Error> {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
         None
     }
 }

--- a/src/nts_ke/client.rs
+++ b/src/nts_ke/client.rs
@@ -84,7 +84,7 @@ impl std::error::Error for ClientError {
             _ => "Something is wrong",
         }
     }
-    fn cause(&self) -> Option<&std::error::Error> {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
         None
     }
 }


### PR DESCRIPTION
Hi!
This PR cleans a compile warning.

- import `Error` and `ErrorKind` only when target_os is equal to "linux"
- add `dyn` because trait objects without an explicit `dyn` are deprecated