### PR TITLE
Server parse client nts_ke/records

### DIFF
--- a/src/nts_ke/client.rs
+++ b/src/nts_ke/client.rs
@@ -33,7 +33,7 @@ use crate::nts_ke::records::{
     Party,
 
     // Structs.
-    RecievedNtsKeRecordState,
+    ReceivedNtsKeRecordState,
 
     // Constants.
     HEADER_SIZE,
@@ -127,7 +127,7 @@ pub fn run_nts_ke_client(
     debug!(logger, "Request transmitted");
     let keys = records::gen_key(tls_stream.sess).unwrap();
 
-    let mut state = RecievedNtsKeRecordState {
+    let mut state = ReceivedNtsKeRecordState {
         finished: false,
         next_protocols: Vec::new(),
         aead_scheme: Vec::new(),

--- a/src/nts_ke/client.rs
+++ b/src/nts_ke/client.rs
@@ -136,7 +136,7 @@ pub fn run_nts_ke_client(
         next_port: None,
     };
 
-    while state.finished == false {
+    while !state.finished {
         let mut header: [u8; HEADER_SIZE] = [0; HEADER_SIZE];
 
         // We should use `read_exact` here because we always need to read 4 bytes to get the

--- a/src/nts_ke/records/mod.rs
+++ b/src/nts_ke/records/mod.rs
@@ -184,7 +184,6 @@ pub struct RecievedNtsKeRecordState {
 pub enum NtsKeParseError {
     RecordAfterEnd,
     ErrorRecord,
-    InvalidRecord,
     NoIpv4AddrFound,
     NoIpv6AddrFound,
 }

--- a/src/nts_ke/records/mod.rs
+++ b/src/nts_ke/records/mod.rs
@@ -171,7 +171,7 @@ pub fn gen_key<T: rustls::Session>(session: &T) -> Result<NTSKeys, TLSError> {
 type Cookie = Vec<u8>;
 
 #[derive(Clone, Debug)]
-pub struct RecievedNtsKeRecordState {
+pub struct ReceivedNtsKeRecordState {
     pub finished: bool,
     pub next_protocols: Vec<u16>,
     pub aead_scheme: Vec<u16>,
@@ -208,7 +208,7 @@ impl fmt::Display for NtsKeParseError {
 /// Read https://tools.ietf.org/html/draft-ietf-ntp-using-nts-for-ntp-19#section-4
 pub fn process_record(
     record: KeRecord,
-    state: &mut RecievedNtsKeRecordState,
+    state: &mut ReceivedNtsKeRecordState,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if state.finished {
         return Err(Box::new(NtsKeParseError::RecordAfterEnd));

--- a/src/nts_ke/server/connection.rs
+++ b/src/nts_ke/server/connection.rs
@@ -269,7 +269,6 @@ impl KeServerConn {
                     Err(DeserializeError::UnknownNotCriticalRecord) => {
                         // If it's not critical, just ignore the error.
                         debug!(self.logger, "unknown record type");
-                        self.shutdown();
                         return;
                     }
                     Err(DeserializeError::UnknownCriticalRecord) => {

--- a/src/nts_ke/server/connection.rs
+++ b/src/nts_ke/server/connection.rs
@@ -33,7 +33,7 @@ use crate::nts_ke::records::{
     DeserializeError,
 
     // Structs.
-    RecievedNtsKeRecordState,
+    ReceivedNtsKeRecordState,
 
     // Enums.
     KnownAeadAlgorithm,
@@ -87,7 +87,7 @@ pub enum KeServerConnState {
     TlsHandshaking,
     /// The TLS handshake is done. It's opened for requests now.
     Opened,
-    /// The reponse is sent after getting a good request.
+    /// The response is sent after getting a good request.
     ResponseSent,
     /// The connection is closed.
     Closed,
@@ -111,7 +111,7 @@ pub struct KeServerConn {
     state: KeServerConnState,
 
     /// The state of NTS-KE.
-    ntske_state: RecievedNtsKeRecordState,
+    ntske_state: ReceivedNtsKeRecordState,
 
     /// The buffer of NTS-KE Stream.
     ntske_buffer: Vec<u8>,
@@ -133,7 +133,7 @@ impl KeServerConn {
         // Create a child logger for the connection.
         let logger = listener.logger().new(slog::o!("client" => listener.addr().to_string()));
 
-        let ntske_state = RecievedNtsKeRecordState {
+        let ntske_state = ReceivedNtsKeRecordState {
             finished: false,
             next_protocols: Vec::new(),
             aead_scheme: Vec::new(),
@@ -291,7 +291,7 @@ impl KeServerConn {
                 self.tls_session
                     .write_all(&response(keys, &self.server_state.rotator,
                                          self.server_state.config.next_port)).unwrap();
-                // Mark that the reponse is sent.
+                // Mark that the response is sent.
                 self.state = KeServerConnState::ResponseSent;
             }
         }

--- a/src/nts_ke/server/connection.rs
+++ b/src/nts_ke/server/connection.rs
@@ -269,7 +269,6 @@ impl KeServerConn {
                     Err(DeserializeError::UnknownNotCriticalRecord) => {
                         // If it's not critical, just ignore the error.
                         debug!(self.logger, "unknown record type");
-                        return;
                     }
                     Err(DeserializeError::UnknownCriticalRecord) => {
                         // TODO: This should propertly handled by sending an Error record.

--- a/src/nts_ke/server/connection.rs
+++ b/src/nts_ke/server/connection.rs
@@ -234,7 +234,7 @@ impl KeServerConn {
 
             let keys = gen_key(&self.tls_session).unwrap();
 
-            while self.ntske_state.finished == false {
+            while !self.ntske_state.finished {
                 // need to read 4 bytes to get the header.
                 if reader.len() < HEADER_SIZE {
                     info!(self.logger, "readable nts-ke stream is not enough to read header");


### PR DESCRIPTION
Hi!
This PR is related to #25 .

- make `nts_ke/server` to parse client records
- modify process_record() to allow both `nts_ke/client` and `nts_ke/server` to call it

With this, `nts_ke/server` will parse client records but not negotiate the next protocol as well as other settings.
First, I made `nts_ke/server` to parse.
