### PR TITLE
Remove unnecessary uses of cursor and move towards preallocation

### DIFF
--- a/src/ntp/server/server.rs
+++ b/src/ntp/server/server.rs
@@ -388,7 +388,9 @@ fn response(
             }
         }
     } else {
-        Ok(serialize_header(resp_header))
+        let mut out = Vec::with_capacity(48);
+        serialize_header(resp_header, &mut out);
+        Ok(out)
     }
 }
 


### PR DESCRIPTION
This should help reduce the number of realloc calls we see. Yet to be done is a single allocation API: that will require some more intrusive length functions.