### PR TITLE
Change default port to 4460 according to IANA ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ We use cargo to build the software. `docker-compose up` will spawn several Docke
 **Running**
 Run the NTS client using `./target/release/cfnts client [--4 | --6] [-p <server-port>] [-c <trusted-cert>] [-n <other name>]  <server-hostname>`
 
-Default port is `1234`. 
+Default port is `4460`. 
 
 Using `-4` forces the use of ipv4 for all connections to the server, and using `-6` forces the use of ipv6. 
 These two arguments are mutually exclusive. If neither of them is used, then the client will use whichever one

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -17,7 +17,7 @@ fn create_clap_client_subcommand<'a, 'b>() -> App<'a, 'b> {
 
         // The rest will be passed as unrequired command-line options.
         Arg::with_name("port").long("port").short("p").takes_value(true).required(false)
-            .help("Specifies NTS server's port. The default port number is 1234."),
+            .help("Specifies NTS server's port. The default port number is 4460."),
         Arg::with_name("cert").long("cert").short("c").takes_value(true).required(false)
             .help("Specifies a path to the trusted certificate in PEM format."),
         Arg::with_name("ipv4").long("ipv4").short("4").conflicts_with("ipv6")

--- a/src/nts_ke/client.rs
+++ b/src/nts_ke/client.rs
@@ -43,7 +43,7 @@ use crate::sub_command::client::ClientConfig;
 type Cookie = Vec<u8>;
 
 const DEFAULT_NTP_PORT: u16 = 123;
-const DEFAULT_KE_PORT: u16 = 1234;
+const DEFAULT_KE_PORT: u16 = 4460;
 const DEFAULT_SCHEME: u16 = 0;
 const TIMEOUT: Duration = Duration::from_secs(15);
 

--- a/tests/nts-ke-config.yaml
+++ b/tests/nts-ke-config.yaml
@@ -1,5 +1,5 @@
 addr:
-  - "[::]:1234"
+  - "[::]:4460"
 tls_key_file: tests/tls-pkcs8.pem
 tls_cert_file: tests/chain.pem # Expect PEM.
 cookie_key_file: tests/cookie.key # TODO: store and read as pem files, or read bytes directly from file?


### PR DESCRIPTION
The IANA appears to have selected 4460 as the Network Time Security-Key Establishment port. [Link](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=4460)